### PR TITLE
Fix logout link

### DIFF
--- a/views/user_info.erb
+++ b/views/user_info.erb
@@ -1,8 +1,8 @@
 <div class="p2 bg-green white clearfix">
   <% if userinfo %>
-    <form action="/auth/saml/logout" method="POST" class="right sm-show">
-      <button type="submit" class="btn p0 h6 white">Log out</button>
-    </form>
+    <div class="right sm-show">
+      <a href="/" class="btn p0 h6 white">Log out</button>
+    </div>
   <% end %>
   <span class="bold">Success!</span>
   <% if userinfo %>


### PR DESCRIPTION
@nickbristow thanks for adding the logout button!

As currently written, this OIDC app is stateless, so there's no real logging out to do. The saml logout URL doesn't work for OIDC, so this just links back home to log out.