### PR TITLE
Switch to HTTParty for easy basic auth support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-IDP_SP_URL: 'http://localhost:3000/api/service_provider'
+IDP_SP_URL: 'http://localhost:3000'
 ACR_VALUES: 'http://idmanagement.gov/ns/assurance/loa/1'
 REDIRECT_URI: 'http://localhost:9292/auth/result'
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.3.3'
 
 gem 'activesupport'
 gem 'dotenv'
-gem 'http'
+gem 'httparty'
 gem 'json-jwt'
 gem 'jwt'
 gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,20 +26,11 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
-    domain_name (0.5.20170223)
-      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.2.0)
     equalizer (0.0.11)
     hashdiff (0.3.2)
-    http (2.2.1)
-      addressable (~> 2.3)
-      http-cookie (~> 1.0)
-      http-form_data (~> 1.0.1)
-      http_parser.rb (~> 0.6.0)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
-    http-form_data (1.0.1)
-    http_parser.rb (0.6.0)
+    httparty (0.14.0)
+      multi_xml (>= 0.5.2)
     i18n (0.8.1)
     ice_nine (0.11.2)
     json-jwt (1.7.1)
@@ -53,6 +44,7 @@ GEM
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     multi_json (1.12.1)
+    multi_xml (0.6.0)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     parser (2.4.0.0)
@@ -107,9 +99,6 @@ GEM
     tilt (2.0.6)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.2)
     unicode-display_width (1.1.3)
     url_safe_base64 (0.2.2)
     virtus (1.0.5)
@@ -128,7 +117,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   dotenv
-  http
+  httparty
   json-jwt
   jwt
   nokogiri

--- a/app.rb
+++ b/app.rb
@@ -3,7 +3,7 @@ require 'dotenv/load'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/object/to_query'
 require 'erb'
-require 'http'
+require 'httparty'
 require 'json/jwt'
 require 'jwt'
 require 'openssl'
@@ -42,12 +42,12 @@ class OpenidConnectRelyingParty < Sinatra::Base
 
   def openid_configuration
     @openid_configuration ||= begin
-      json(HTTP.get(URI.join(SERVICE_PROVIDER, '/.well-known/openid-configuration')))
+      json(HTTParty.get(URI.join(SERVICE_PROVIDER, '/.well-known/openid-configuration')).body)
     end
   end
 
   def token(code)
-    json HTTP.post(
+    json HTTParty.post(
       openid_configuration[:token_endpoint],
       json: {
         grant_type: 'authorization_code',
@@ -81,7 +81,7 @@ class OpenidConnectRelyingParty < Sinatra::Base
   end
 
   def idp_public_key
-    certs_response = json(HTTP.get(openid_configuration[:jwks_uri]))
+    certs_response = json(HTTParty.get(openid_configuration[:jwks_uri]).body)
 
     JSON::JWK.new(certs_response[:keys].first).to_key
   end


### PR DESCRIPTION
**Why**: Pointing `IDP_SP_URL` at a site with basic auth (as in AWS)
will prevent the Net::HTTP gem from simple GETs.