### PR TITLE
Fix bug from conversion to HTTParty with JSON response

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -49,13 +49,13 @@ class OpenidConnectRelyingParty < Sinatra::Base
   def token(code)
     json HTTParty.post(
       openid_configuration[:token_endpoint],
-      json: {
+      body: {
         grant_type: 'authorization_code',
         code: code,
         client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
         client_assertion: client_assertion_jwt,
       }
-    )
+    ).body
   end
 
   def client_assertion_jwt

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -53,7 +53,12 @@ RSpec.describe OpenidConnectRelyingParty do
         }.to_json)
 
       stub_request(:post, token_endpoint).
-        to_return(body: {
+        with(body: {
+          grant_type: 'authorization_code',
+          code: code,
+          client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+          client_assertion: kind_of(String),
+        }).to_return(body: {
           id_token: id_token,
         }.to_json)
     end


### PR DESCRIPTION
The migration to HTTParty had two small bugs:

1. HTTParty will implicitly JSON parse objects unless you do `.body` which caused problems here
2. the POST `body` key was wrong, and the old spec to check for POSTs to the token endpoint was not specific enough to catch it