### PR TITLE
Make sure nonce and state keys are at least 32 characters

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -23,8 +23,8 @@ class OpenidConnectRelyingParty < Sinatra::Base
       acr_values: ENV['ACR_VALUES'],
       scope: 'openid email',
       redirect_uri: ENV['REDIRECT_URI'],
-      state: SecureRandom.urlsafe_base64,
-      nonce: SecureRandom.urlsafe_base64,
+      state: SecureRandom.hex,
+      nonce: SecureRandom.hex,
       prompt: 'select_account',
     }.to_query
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe OpenidConnectRelyingParty do
       expect(auth_uri_params[:redirect_uri]).to eq('http://localhost:9292/auth/result')
       expect(auth_uri_params[:response_type]).to eq('code')
       expect(auth_uri_params[:prompt]).to eq('select_account')
-      expect(auth_uri_params[:nonce]).to be
-      expect(auth_uri_params[:state]).to be
+      expect(auth_uri_params[:nonce].length).to be >= 32
+      expect(auth_uri_params[:state].length).to be >= 32
     end
   end
 


### PR DESCRIPTION
We updated the minimum length requirements in the IDP, so this SP needs to behave correctly.