### PR TITLE
Make CLIENT_ID configurable via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,4 @@
 IDP_SP_URL: 'http://localhost:3000'
 ACR_VALUES: 'http://idmanagement.gov/ns/assurance/loa/1'
 REDIRECT_URI: 'http://localhost:9292/auth/result'
-
-# SP_NAME: 'changeme'
-# SP_PASS: 'changeme'
+CLIENT_ID: 'urn:gov:gsa:openidconnect:sp:sinatra'

--- a/app.rb
+++ b/app.rb
@@ -13,8 +13,7 @@ require 'time'
 
 class OpenidConnectRelyingParty < Sinatra::Base
   SERVICE_PROVIDER = ENV['IDP_SP_URL']
-
-  CLIENT_ID = 'urn:gov:gsa:openidconnect:sp:sinatra'
+  CLIENT_ID = ENV['CLIENT_ID']
 
   get '/' do
     authorization_url = openid_configuration[:authorization_endpoint] + '?' + {

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe OpenidConnectRelyingParty do
       auth_uri_params = Rack::Utils.parse_nested_query(auth_uri.query).with_indifferent_access
 
       expect(auth_uri_params[:redirect_uri]).to eq('http://localhost:9292/auth/result')
+      expect(auth_uri_params[:client_id]).to_not be_empty
+      expect(auth_uri_params[:client_id]).to eq(ENV['CLIENT_ID'])
       expect(auth_uri_params[:response_type]).to eq('code')
       expect(auth_uri_params[:prompt]).to eq('select_account')
       expect(auth_uri_params[:nonce]).to be


### PR DESCRIPTION
(also since the credentials for basic auth are now in the IDP SP URL, no need to have configs for them)