### PR TITLE
Add ability to config IDP URLs for basic auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,9 @@
 IDP_SP_URL: 'http://localhost:3000'
+
+# IDP with basic authentication
+IDP_USER: 'USERNAME'
+IDP_PASSWORD: 'PASSWORD'
+
 ACR_VALUES: 'http://idmanagement.gov/ns/assurance/loa/1'
 REDIRECT_URI: 'http://localhost:9292/auth/result'
 CLIENT_ID: 'urn:gov:gsa:openidconnect:sp:sinatra'


### PR DESCRIPTION
 **Why:** Using an IDP behind basic auth was causing an issue. The app currently receives a configuration from the IDP. From this configuration it retrieves uris for `token_endpoint`, `jwks_uri`, and `authorization_endpoint`. 

These endpoints are also behind basic auth and the app needs to authenticate before calling them. 

This is a work around where we can place the authentication in the configuration for each of these endpoints. 