### PR TITLE
Hanadle callback errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,7 @@ Metrics/ClassLength:
   CountComments: false
   Max: 100
   Exclude:
+  - app.rb
   - spec/**/*
 
 Metrics/LineLength:

--- a/app.rb
+++ b/app.rb
@@ -11,6 +11,7 @@ require 'securerandom'
 require 'sinatra/base'
 require 'time'
 
+# rubocop:disable Metrics/ClassLength
 class OpenidConnectRelyingParty < Sinatra::Base
   SERVICE_PROVIDER = ENV['IDP_SP_URL']
   CLIENT_ID = ENV['CLIENT_ID']
@@ -25,10 +26,18 @@ class OpenidConnectRelyingParty < Sinatra::Base
   end
 
   get '/auth/result' do
-    token_response = token(params[:code])
-    userinfo_response = userinfo(token_response[:id_token])
+    code = params[:code]
 
-    erb :success, locals: { userinfo: userinfo_response }
+    if code
+      token_response = token(code)
+      userinfo_response = userinfo(token_response[:id_token])
+
+      erb :success, locals: { userinfo: userinfo_response }
+    else
+      error = params[:error] || 'missing callback param code'
+
+      erb :errors, locals: { error: error }
+    end
   end
 
   private
@@ -129,3 +138,4 @@ class OpenidConnectRelyingParty < Sinatra::Base
     SecureRandom.hex
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app.rb
+++ b/app.rb
@@ -11,7 +11,6 @@ require 'securerandom'
 require 'sinatra/base'
 require 'time'
 
-# rubocop:disable Metrics/ClassLength
 class OpenidConnectRelyingParty < Sinatra::Base
   SERVICE_PROVIDER = ENV['IDP_SP_URL']
   CLIENT_ID = ENV['CLIENT_ID']
@@ -34,7 +33,7 @@ class OpenidConnectRelyingParty < Sinatra::Base
 
       erb :success, locals: { userinfo: userinfo_response }
     else
-      error = params[:error] || 'missing callback param code'
+      error = params[:error] || 'missing callback param: code'
 
       erb :errors, locals: { error: error }
     end
@@ -138,4 +137,3 @@ class OpenidConnectRelyingParty < Sinatra::Base
     SecureRandom.hex
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -112,5 +112,13 @@ RSpec.describe OpenidConnectRelyingParty do
       get logout_link[:href]
       expect(last_response.body).to_not include(email)
     end
+
+    it 'renders an error message when there is one' do
+      get '/auth/result', error: 'access_denied'
+
+      doc = Nokogiri::HTML(last_response.body)
+
+      expect(doc.text).to include('access_denied')
+    end
   end
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -120,5 +120,13 @@ RSpec.describe OpenidConnectRelyingParty do
 
       expect(doc.text).to include('access_denied')
     end
+
+    it 'renders a default error message when no code or explicit error code' do
+      get '/auth/result'
+
+      doc = Nokogiri::HTML(last_response.body)
+
+      expect(doc.text).to include('missing callback param: code')
+    end
   end
 end


### PR DESCRIPTION
Make sure we clean up and merge @nickbristow's https://github.com/18F/identity-openidconnect-sinatra/pull/17 first (since this uses the error template that PR added)


---

Updates the sample app to gracefully handle explicit errors from the IDP