### PR TITLE
Add support for the RP-initiated logout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,5 @@ IDP_USER: 'USERNAME'
 IDP_PASSWORD: 'PASSWORD'
 
 ACR_VALUES: 'http://idmanagement.gov/ns/assurance/loa/1'
-REDIRECT_URI: 'http://localhost:9292/auth/result'
+REDIRECT_URI: 'http://localhost:9292/'
 CLIENT_ID: 'urn:gov:gsa:openidconnect:sp:sinatra'

--- a/views/success.erb
+++ b/views/success.erb
@@ -1,2 +1,2 @@
-<%= erb :user_info, locals: { userinfo: userinfo } %>
+<%= erb :user_info, locals: { userinfo: userinfo, logout_uri: logout_uri } %>
 <%= erb :page_content %>

--- a/views/user_info.erb
+++ b/views/user_info.erb
@@ -1,7 +1,7 @@
 <div class="p2 bg-green white clearfix">
   <% if userinfo %>
     <div class="right sm-show">
-      <a href="/" class="btn p0 h6 white">Log out</button>
+      <a href="<%= logout_uri %>" class="btn p0 h6 white">Log out</a>
     </div>
   <% end %>
   <span class="bold">Success!</span>


### PR DESCRIPTION
**Why**: Previous logout button did not end the IDP session

Corresponds to https://github.com/18F/identity-idp/pull/1437